### PR TITLE
Fix tox build and add python app workflow

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -22,12 +22,10 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: "3.9"
-    - name: Install Poetry
-      uses: snok/install-poetry@v1.3.4        
-    - name: Install dependencies
+    - name: Install tox
       run: |
-        poetry install
+        pip install tox
     - name: Test
       run: |
-        poetry run tox -e pytest
+        tox -e pytest
 

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ "develop", "main" ]
   pull_request:
-    branches: [ "develop", "main ]
+    branches: [ "develop", "main" ]
 
 permissions:
   contents: read

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -5,9 +5,9 @@ name: Python application
 
 on:
   push:
-    branches: [ "develop" ]
+    branches: [ "develop", "main" ]
   pull_request:
-    branches: [ "develop" ]
+    branches: [ "develop", "main ]
 
 permissions:
   contents: read
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.10
+    - name: Set up Python 3.9
       uses: actions/setup-python@v3
       with:
         python-version: "3.9"

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,33 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Python application
+
+on:
+  push:
+    branches: [ "develop" ]
+  pull_request:
+    branches: [ "develop" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.9"
+    - name: Install Poetry
+      uses: snok/install-poetry@v1.3.4        
+    - name: Install dependencies
+      run: |
+        poetry install
+    - name: Test
+      run: |
+        poetry run tox -e pytest
+

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ poetry install
 ### tox
 
 ```shell
-poetry run tox -e pytest
+tox -e pytest
 ```
 
 ## build

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ michar --help
 brew install pyenv
 pyenv install 3.9
 pyenv local 3.9
+brew install pipx
+pipx install tox
 ```
 
 #### poetry

--- a/poetry.lock
+++ b/poetry.lock
@@ -966,16 +966,6 @@ files = [
 ]
 
 [[package]]
-name = "importlib"
-version = "1.0.4"
-description = "Backport of importlib.import_module() from Python 2.7"
-optional = false
-python-versions = "*"
-files = [
-    {file = "importlib-1.0.4.zip", hash = "sha256:b6ee7066fea66e35f8d0acee24d98006de1a0a8a94a8ce6efe73a9a23c8d9826"},
-]
-
-[[package]]
 name = "importlib-metadata"
 version = "7.0.0"
 description = "Read metadata from Python packages"
@@ -2857,6 +2847,7 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -4259,4 +4250,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "a1e1528559e018322adb35b1c6b08e112d18f5b47d51a4a88c6e01d4a8782481"
+content-hash = "96f97979cf0f4e80c9d7c6e41cdb56042344ea0c693298fd521629dbd3a7df99"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ build = "^1.0.3"
 pytest = "^7.4.3"
 black = "^23.10.1"
 mypy = "^1.6.1"
-importlib = "^1.0.4"
 isort = "^5.13.0"
 jupyter = "^1.0.0"
 pandas = "^2.1.4"
@@ -36,7 +35,7 @@ selenium = "^4.16.0"
 webdriver-manager = "^4.0.1"
 
 [tool.poetry.scripts]
-michar = "src.michar.cli.app.michar:main"
+michar = "michar.cli.app.michar:main"
 
 
 [build-system]

--- a/src/michar/cli/app/michar.py
+++ b/src/michar/cli/app/michar.py
@@ -7,7 +7,6 @@ from trogon import tui
 
 
 debug_option: click.Option = click.option("-d", "--debug", default=False, is_flag=True, help="debug logs")
-help_option: click.Option = click.option("-h", "--help", is_flag=True, default=None, help="show help and exit")
 
 log: logging.Logger = util.get_logger()
 
@@ -18,7 +17,6 @@ class MichiOptions(object):
 
 @tui(command="ui", help="Open terminal UI")
 @click.group(context_settings=dict(help_option_names=["-h", "--help"]), chain=True)
-@help_option
 @debug_option
 @click.version_option(__version__, prog_name=__name__)
 @click.pass_context

--- a/src/michar/cli/app/michar.py
+++ b/src/michar/cli/app/michar.py
@@ -20,7 +20,7 @@ class MichiOptions(object):
 @debug_option
 @click.version_option(__version__, prog_name=__name__)
 @click.pass_context
-def gooza(ctx, help, debug) -> None:
+def gooza(ctx, debug) -> None:
     if debug:
         for logger in [logging.getLogger(name) for name in logging.root.manager.loggerDict]:
             logger.setLevel(logging.DEBUG)

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ env_list =
     py39
 
 [testenv]
+deps = setuptools
 commands = 
     michar --help
     michar --version

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+isolated_build = True
 min_version = 4.0
 env_list =
     py39

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,13 @@
 [tox]
 isolated_build = True
-deps = setuptools
 min_version = 4.0
 env_list =
     py39
 
 [testenv]
 commands = 
-    micha --help
-    micha --version
+    michar --help
+    michar --version
 
 [testenv:pytest]
 deps = pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 isolated_build = True
+deps = setuptools
 min_version = 4.0
 env_list =
     py39


### PR DESCRIPTION
## Description

- Add workflow to build the main and develop branches
- The workflow runs `tox -e pytest`
- Uncovered some issues I fixed along the way to verify the action
  - pyproject.toml had an incorrect script specification
  - the `--help` argument was broken
  - removed `importlib` dependency; this was causing the action and my local environment to fail while running tox

## Rationale

GitHub Actions will now catch any build and test regressions, including some that already happened in the past but are now fixed